### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ### First and foremost...
 
 This was an experiment in *vibe coding*.
-Most credit for the original shader goes to [ShaderToy](https://www.shadertoy.com/). I was merely poking around, seeing if layering vibe-driven tweaks could make it more interesting.  Also see attributions.txt for other glsl shaders that I either out right used or borrowed from.  I'm trying now to keep attributions.txt in the root cause AI tends to remove comments in code as it see fit. 
+Most credit for the original shader goes to [ShaderToy](https://www.shadertoy.com/). I was merely poking around, seeing if layering vibe-driven tweaks could make it more interesting.  Also see attributions.txt for other glsl shaders that I either outright used or borrowed from.  I'm trying now to keep attributions.txt in the root cause AI tends to remove comments in code as it see fit. 
 
 ---
 


### PR DESCRIPTION
## Summary
- fix typos in README

## Testing
- `grep -n "outright used" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_68464f87d3688333a2667200e591d0b0